### PR TITLE
Add move-docs-and-delete-account script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # 🧰 Grist utils by the French administration
 
 This repository gathers many utils made by the French administration. You may go through the folders to discover each of them.
+
+## Status of these utils
+
+These utils are provided **AS IS**, WITHOUT WARRANTY OF ANY KIND.
+
+The statuses and the documentation given for these scripts are just informative. It is the responsibility of their user to review the code they are about to run, and understand the consequences.

--- a/backup-checks/README.md
+++ b/backup-checks/README.md
@@ -1,5 +1,7 @@
 # Check backups are made on S3
 
+**Status: ✅ Ready to be used in production**
+
 Check our backups are made on our S3 storage.
 
 ## Prerequisites

--- a/fetch-github-issues/README.md
+++ b/fetch-github-issues/README.md
@@ -1,5 +1,7 @@
 # Fetch Github issues
 
+**Status: ✅ Ready to be used in production**
+
 This script gathers the issues and pull requests in the [French administration board](https://github.com/orgs/gristlabs/projects/1) 
 and prepares a text so we can add information about our progress.
 

--- a/move-docs-and-delete-account/README.md
+++ b/move-docs-and-delete-account/README.md
@@ -1,0 +1,37 @@
+# gen-sql-move-docs-and-delete-account
+
+**Status: 🧪 Experimental**
+
+**Notes**: 
+- Used for a user in production once with success and using Postgresql, but not tested against a Sqlite3 database. Also there are some fragile assumptions (like the name of the personal workspace). 
+- ALSO BE AWARE THAT THIS IS A DESTRUCTIVE SCRIPT (IT DELETES AN ACCOUNT PERMANENTLY).
+
+## Description
+
+⚠️  This script supposes you use a Postgresql database. It will probably work on Sqlite, but be cautious and test by your own before using it for that database.
+
+Scenario: a user changed their email address and already landed to grist with their new email address.
+Then the new account and the old account exist.
+
+This main ideas of the script does the following (check the comments of the script for the details):
+ - move every workspace of their personal org to the new one;
+ - change every permission previously granted to the old account so they are granted to the new one;
+ - and finally delete the old account;
+
+## Usage
+
+```bash
+./gen-sql-move-docs-and-delete-account.bash --src=... --dst=... [--moved_suffix=...]
+```
+
+Where:
+ - `--src` is the **normalized** email of the account which will be deleted
+ - `--dst` is the **normalized** email of the account which will receive the workspaces (so the docs);
+ - `--moved_suffix` (optional) is the suffix to add to the moved workspaces;
+
+Example of use:
+```
+./gen-sql-move-docs-and-delete-account.bash --src=deleted-account@example.com --dst=dst@example.com --move_suffix="__from_deleted_account"
+```
+
+The result is a SQL query you have to execute directly in the database, with a transaction so if a step fails, all the changes are automatically rolled back.

--- a/move-docs-and-delete-account/gen-sql-move-docs-and-delete-account.bash
+++ b/move-docs-and-delete-account/gen-sql-move-docs-and-delete-account.bash
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Retrieve arguments passed to the command
+
+moved_suffix="__moved"
+
+for i in "$@"; do
+  case $i in
+    -s=*|--src=*)
+      src="${i#*=}"
+      shift
+      ;;
+    -d=*|--dst=*)
+      dst="${i#*=}"
+      shift
+      ;;
+    --moved_suffix=*)
+      moved_suffix="${i#*=}"
+      shift
+      ;;
+    *)
+      # unknown option
+      ;;
+  esac
+done
+
+echo_red() {
+  echo -e "\033[0;31m$1\033[0m"
+}
+
+echo_green() {
+  echo -e "\033[0;32m$1\033[0m"
+}
+
+if [ -z "$src" ] || [ -z "$dst" ]; then
+  echo_red "Usage: $0 --src=... --dst=... [--moved_suffix=...]"
+  exit 1
+fi
+
+cat_cmd=$(which bat batcat cat | head -n 1)
+declare -a cat_cmd_args
+if [[ $(basename "$cat_cmd") == "bat"* ]]; then
+  cat_cmd_args+=("-l" "sql" "-p" "--paging=never")
+fi
+
+echo_red "Account $src will be deleted"
+echo_green "Account $dst will receive the docs"
+echo ""
+read -p "Press enter to continue"
+echo ""
+
+$cat_cmd ${cat_cmd_args[@]} <<EOF
+DROP TABLE IF EXISTS source_info;
+
+CREATE TEMPORARY TABLE source_info as select u.id as user_id, w.id as workspace_id, o.id as org_id
+from logins l join users u on u.id=l.user_id
+  join orgs o on o.owner_id=u.id
+  join workspaces w on w.org_id=o.id
+where l.email='${src}' and o.name='Personal';
+
+select * from source_info;
+
+DROP VIEW IF EXISTS target_info;
+
+CREATE TEMPORARY VIEW target_info as select u.id as user_id, o.id as org_id
+from logins l join users u on u.id=l.user_id
+  join orgs o on o.owner_id=u.id
+  join acl_rules ar on ar.org_id=o.id
+where l.email='${dst}' and o.name='Personal' and ar.permissions=63
+LIMIT 1;
+
+select * from target_info;
+
+begin;
+
+UPDATE workspaces set name=(name || '${moved_suffix}'), org_id=(SELECT t.org_id from target_info t) where id in (SELECT s.workspace_id from source_info s) returning *; -- Change workspace orgs and rename their name won't conflict with the target organization ones
+
+WITH source_and_target_org_id_match as (
+  select src_grp.id as src_grp_id, dst_grp.id as dst_grp_id
+  from groups src_grp join groups dst_grp on src_grp.name=dst_grp.name
+    join acl_rules src_ar on src_grp.id=src_ar.id 
+    join acl_rules dst_ar on dst_grp.id=dst_ar.id
+  where src_ar.org_id=(select distinct(org_id) from source_info) and dst_ar.org_id=(select distinct(org_id) from target_info)
+)
+UPDATE group_groups 
+set subgroup_id=(select dst_grp_id from source_and_target_org_id_match where src_grp_id=subgroup_id)
+where subgroup_id in (select src_grp_id from source_and_target_org_id_match) returning *; -- Make moved workspace inherit their rights from the target org
+
+update group_users set user_id=(select distinct(user_id) from target_info) 
+where user_id=(select distinct(user_id) from source_info) 
+and not exists (select 1 from group_users gu where group_users.group_id=gu.group_id and gu.user_id=(select distinct(user_id) from target_info))
+returning *; -- Remove every permissions of the old user and grant them to the new one, if not already existing
+
+delete from group_users where user_id=(select distinct(user_id) from source_info) returning *;
+
+update docs set created_by=(select distinct(user_id) from target_info) where created_by=(select distinct(user_id) from source_info) returning *; -- Update the docs so they are marked as being created by the new account instead. FIXME: required? A good idea regarding the history?
+
+UPDATE aliases set org_id=(select distinct(org_id) from target_info) where doc_id in (select d.id from docs d join source_info s on d.workspace_id=s.workspace_id) returning *; -- Update the org in the aliases.
+
+-- Delete the old account
+delete from acl_rules where acl_rules.org_id=(select id from orgs where orgs.owner_id=(select distinct(user_id) from source_info));
+DELETE from logins where user_id=(select distinct(user_id) from source_info);
+DELETE from orgs where owner_id=(select distinct(user_id) from source_info);
+DELETE from users where id=(select distinct(user_id) from source_info);
+
+commit;
+EOF


### PR DESCRIPTION
## Context

Open-source the bash script which generates the SQL to move documents (actually workspaces) from one account to another, deleting the source account by the same time.

## Proposed solution

I also documented how to use it, and warn about the experimental status.

I also warn the user about the absence of warranty (just like stated in the LICENSE), and explain this is their responsibility to review the code of these utils before executing it.