### PR TITLE
chore: Adding more consistency in shell scripts

### DIFF
--- a/backup-checks/check-backups.sh
+++ b/backup-checks/check-backups.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/extract-history/extract-history.sh
+++ b/extract-history/extract-history.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo_err() {
   echo -e "\033[31m${1}\033[0m"

--- a/grist-deployment-tests/test.sh
+++ b/grist-deployment-tests/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$USER_API_KEY" ]; then
   echo -n "Api key: "

--- a/s3-migrate/clean-history.sh
+++ b/s3-migrate/clean-history.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 cd /grist
 mv ${1} "${1}.grist"
 yarn cli history prune "${1}.grist" 10


### PR DESCRIPTION
As we are working in a multi os domain (Linux/mac/windows) we need to take care of different policies on the way shells are called in shebangs.

`#!/bin bash` do not work on macOs and on certain linux having done strangely the usrmerge migration.

So I propose to use the more consistent
`#!/usr/bin/env bash`

In the same spirit, I changed one `.bash` extension to `.sh`