### PR TITLE
🐛(e2e): fix Login e2e tests when maintenance popin appears

### DIFF
--- a/grist-deployment-tests/test/e2e/test.e2e.js
+++ b/grist-deployment-tests/test/e2e/test.e2e.js
@@ -7,8 +7,8 @@ describe("Login", () => {
   it("should login and logout with valid credentials using ProConnect OIDC Identity Provider", async () => {
     // Given
     await HomePage.open();
-    if (await HomePage.userAgreementPopup.isDisplayed()) {
-      await HomePage.acceptUserAgreements();
+    if (await HomePage.maintenancePopin.isDisplayed()) {
+      await HomePage.acknowledgeMaintenance();
     }
     await HomePage.goToLogin();
 

--- a/grist-deployment-tests/test/pageobjects/homepage.page.js
+++ b/grist-deployment-tests/test/pageobjects/homepage.page.js
@@ -20,16 +20,16 @@ class HomePage extends Page {
     return $(".test-dm-log-out");
   }
 
-  get userAgreementPopup() {
-    return $("#agreementPopin");
+  get maintenancePopin() {
+    return $("#maintenancePopin");
   }
 
-  get userAgreementCheckbox() {
-    return $("#jaccepte");
+  get acknowledgeMaintenanceCheckbox() {
+    return $("#jaiCompris");
   }
 
-  get userAgreementSubmitBtn() {
-    return $("#fermerPopinAgreement");
+  get closeMaintenancePopinBtn() {
+    return $("#fermerPopinMaintenance");
   }
 
   open() {
@@ -45,9 +45,9 @@ class HomePage extends Page {
     await this.logoutMenu.click();
   }
 
-  async acceptUserAgreements() {
-    await this.userAgreementCheckbox.click();
-    await this.userAgreementSubmitBtn.click();
+  async acknowledgeMaintenance() {
+    await this.acknowledgeMaintenanceCheckbox.click();
+    await this.closeMaintenancePopinBtn.click();
   }
 }
 


### PR DESCRIPTION
In some case, the maitenance popin may appear. In such a case, just make it close before the rest of the tests