### PR TITLE
Daily tests latest

### DIFF
--- a/.github/workflows/grist-deployment-tests.yml
+++ b/.github/workflows/grist-deployment-tests.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Run the API tests
       shell: bash
       env:
-        GRIST_DOMAIN: ${{ secrets.GRIST_DOMAIN }}
+        GRIST_DOMAIN: ${{ vars.GRIST_DOMAIN }}
         USER_API_KEY: ${{ secrets.USER_API_KEY }}
 
       run: |
@@ -46,7 +46,7 @@ jobs:
     - name: Run the e2e tests
       shell: bash
       env:
-        GRIST_DOMAIN: ${{ secrets.GRIST_DOMAIN }}
+        GRIST_DOMAIN: ${{ vars.GRIST_DOMAIN }}
 
       run: |
         cd grist-deployment-tests

--- a/.github/workflows/grist-deployment-tests.yml
+++ b/.github/workflows/grist-deployment-tests.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  run-integration-tests:
     runs-on: ubuntu-latest
     environment: deployment tests
 

--- a/.github/workflows/grist-deployment-tests.yml
+++ b/.github/workflows/grist-deployment-tests.yml
@@ -13,11 +13,19 @@ on:
       - grist-deployment-tests/
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to run the tests on
+        type: choice
+        options:
+          - tests preprod
+          - tests latest
+        default: tests latest
 
 jobs:
   run-integration-tests:
     runs-on: ubuntu-latest
-    environment: deployment tests
+    environment: ${{ inputs.environment || "tests latest" }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/grist-deployment-tests.yml
+++ b/.github/workflows/grist-deployment-tests.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   run-integration-tests:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || "tests latest" }}
+    environment: ${{ inputs.environment || 'tests latest' }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/grist-deployment-tests.yml
+++ b/.github/workflows/grist-deployment-tests.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - grist-deployment-tests/
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/grist-deployment-tests.yml
+++ b/.github/workflows/grist-deployment-tests.yml
@@ -21,6 +21,8 @@ on:
           - tests preprod
           - tests latest
         default: tests latest
+  schedule:
+    - cron: 0 8 * * *
 
 jobs:
   run-integration-tests:


### PR DESCRIPTION
Run the tests daily against the latest environment. Also slightly reworks the test workflow.

The tests currenlty fail against the latest environment but work for preprod. Any lead on what might cause this? It's the e2e tests that fail, API tests run successfully since I've created the API key

[tests for preprod](https://github.com/betagouv/grist-utils/actions/runs/16342616597/job/46168634009)
[tests for latest](https://github.com/betagouv/grist-utils/actions/runs/16342533412/job/46168442459)