### PR TITLE
grist-deployment-tests: credentials not loaded in e2e tests

### DIFF
--- a/.github/workflows/grist-deployment-tests.yml
+++ b/.github/workflows/grist-deployment-tests.yml
@@ -48,8 +48,6 @@ jobs:
       env:
         GRIST_DOMAIN: ${{ vars.GRIST_DOMAIN }}
         USER_API_KEY: ${{ secrets.USER_API_KEY }}
-        USER_LOGIN: ${{ secrets.USER_LOGIN }}
-        USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
 
       run: |
         cd grist-deployment-tests
@@ -59,6 +57,8 @@ jobs:
       shell: bash
       env:
         GRIST_DOMAIN: ${{ vars.GRIST_DOMAIN }}
+        USER_LOGIN: ${{ secrets.USER_LOGIN }}
+        USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
 
       run: |
         cd grist-deployment-tests


### PR DESCRIPTION
My bad, they have been added for the API tests instead of the E2E ones.