### PR TITLE
grist-deployment-tests: add target "opi tests latest" [attente de JCOP]

### DIFF
--- a/.github/workflows/grist-deployment-tests.yml
+++ b/.github/workflows/grist-deployment-tests.yml
@@ -20,7 +20,8 @@ on:
         options:
           - tests preprod
           - tests latest
-        default: tests latest
+          - tests bacasable OPI
+        default: tests preprod
   schedule:
     - cron: 0 8 * * *
 


### PR DESCRIPTION
This is meant to check the environment named "bac à sable OPI" works as expected and check for possible regression quickly.

Also I suggest to switch the default environment to preprod, which I guess is the most run in our CI.