### PR TITLE
Disable antivirus tests as requested by JCOP

### DIFF
--- a/grist-deployment-tests/test/api/api.spec.js
+++ b/grist-deployment-tests/test/api/api.spec.js
@@ -339,15 +339,15 @@ describe("API", function () {
         ),
         expectedStatus: 200,
       },
-      {
-        itMsg: "should reject for malicious pdf",
-        docId: "doc-malicious-attachment",
-        attachmentFilePath: new URL(
-          "../fixtures/attachments/malicious.pdf",
-          import.meta.url,
-        ),
-        expectedStatus: 400,
-      },
+      // {
+      //   itMsg: "should reject for malicious pdf",
+      //   docId: "doc-malicious-attachment",
+      //   attachmentFilePath: new URL(
+      //     "../fixtures/attachments/malicious.pdf",
+      //     import.meta.url,
+      //   ),
+      //   expectedStatus: 400,
+      // },
       {
         itMsg: "should pass for regular grist files",
         docId: "doc-regular-grist",

--- a/grist-deployment-tests/test/e2e/antivirus.e2e.js
+++ b/grist-deployment-tests/test/e2e/antivirus.e2e.js
@@ -12,7 +12,7 @@ import { withTmpTab, withTmpWorkspace } from "./utils.js";
 // These tests are complementary to the API tests.
 // NOTE: We should opt for writing them using Webdriver only when a step is at least not trivial doing so using the API
 // (like publishing a form)
-describe("Antivirus 2", () => {
+describe.skip("Antivirus 2", () => {
   it("should block malicious attachments in form", async () => {
     // Given
     await HomePage.open();


### PR DESCRIPTION
It biases their stats, so they ask not for sending this file anymore.